### PR TITLE
Fix documentation of assertions in Predef

### DIFF
--- a/src/library/scala/Predef.scala
+++ b/src/library/scala/Predef.scala
@@ -36,8 +36,8 @@ import scala.io.StdIn
  *
  *  A set of `assert` functions are provided for use as a way to document
  *  and dynamically check invariants in code. `assert` statements can be elided
- *  at runtime by providing the command line argument `-Xdisable-assertions` to
- *  the `scala` command.
+ *  at compile time by providing the command line argument `-Xdisable-assertions` to
+ *  the `scalac` command.
  *
  *  Variants of `assert` intended for use with static analysis tools are also
  *  provided: `assume`, `require` and `ensuring`. `require` and `ensuring` are


### PR DESCRIPTION
Assertions can be elided at compile time; they generate no runtime conditional code and are in fact run unconditionally if not elided during compilation. Updates documentation to reflect that.
